### PR TITLE
SoundCloud following changes

### DIFF
--- a/src/main/java/org/springframework/social/soundcloud/api/impl/AbstractUserTemplate.java
+++ b/src/main/java/org/springframework/social/soundcloud/api/impl/AbstractUserTemplate.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.social.soundcloud.api.impl;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -29,6 +27,8 @@ import org.springframework.social.soundcloud.api.impl.json.PlaylistList;
 import org.springframework.social.soundcloud.api.impl.json.SoundCloudProfileList;
 import org.springframework.social.soundcloud.api.impl.json.TrackList;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
 
 public abstract class AbstractUserTemplate extends AbstractSoundCloudResourceOperations implements UserOperations {
 	
@@ -91,7 +91,8 @@ public abstract class AbstractUserTemplate extends AbstractSoundCloudResourceOpe
 	public Page<SoundCloudProfile> getFollowing(Pageable pageable) {
 
 		 SoundCloudProfile soundCloudProfile = getUserProfile();
-		 List<SoundCloudProfile> profiles = restTemplate.getForObject(getApiResourceUrl("/followings",pageable), SoundCloudProfileList.class);	 
+		 SoundCloudProfileList profileList = restTemplate.getForObject(getApiResourceUrl("/followings",pageable), SoundCloudProfileList.class);
+        List<SoundCloudProfile> profiles = profileList.getCollection();
 		 if (pageable == null)
 		 {
 			 // TODO

--- a/src/main/java/org/springframework/social/soundcloud/api/impl/json/SoundCloudProfileList.java
+++ b/src/main/java/org/springframework/social/soundcloud/api/impl/json/SoundCloudProfileList.java
@@ -15,15 +15,35 @@
  */
 package org.springframework.social.soundcloud.api.impl.json;
 
-import java.util.ArrayList;
-
 import org.springframework.social.soundcloud.api.SoundCloudProfile;
 
-public class SoundCloudProfileList extends ArrayList<SoundCloudProfile> {
+import java.io.Serializable;
+import java.util.ArrayList;
+
+public class SoundCloudProfileList implements Serializable{
 
 	/**
 	 * 
 	 */
 	private static final long serialVersionUID = 1L;
 
+    public ArrayList<SoundCloudProfile> getCollection() {
+        return collection;
+    }
+
+    public void setCollection(ArrayList<SoundCloudProfile> collection) {
+        this.collection = collection;
+    }
+
+    private ArrayList<SoundCloudProfile> collection;
+
+    private String next_href;
+
+    public String getNext_href() {
+        return next_href;
+    }
+
+    public void setNext_href(String next_href) {
+        this.next_href = next_href;
+    }
 }


### PR DESCRIPTION
SoundCloud now has "collection" and "next_href" elements in their JSON response. This was causing the call to blow up. I added those values and also had to change how the response is serialized to the "profiles" variable.